### PR TITLE
Add option to pluralize snake case model names

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -274,6 +274,8 @@ Checks that the mapped name of a model is the expected snake case.
 z.object({
   compoundWords: z.array(z.string()).optional(),
   trimPrefix: z.string().optional(),
+  pluralize: z.boolean().optional(),
+  irregularPlurals: z.record(z.string()).optional(),
 })
   .strict()
   .optional();
@@ -330,6 +332,26 @@ model GraphQLPersistedQuery {
 model GraphQLPersistedQuery {
   id String @id
   @@map(name: "graph_q_l_persisted_query")
+}
+```
+
+#### With `{ pluralize: true }`
+
+```prisma
+// good
+model UserRole {
+  id String @id
+  @@map(name: "user_roles")
+}
+
+// bad
+model UserRole {
+  id String @id
+}
+
+model UserRole {
+  id String @id
+  @@map(name: "user_role")
 }
 ```
 

--- a/src/common/snake-case.ts
+++ b/src/common/snake-case.ts
@@ -1,3 +1,5 @@
+import pluralize from 'pluralize';
+
 /**
  * Returns a snake case string expected based on input string,
  * accounting for compound words and prefix.
@@ -19,6 +21,18 @@ export function toSnakeCase(
      * to "graphql".
      */
     compoundWords?: string[];
+
+    /**
+     * Whether to convert to singular or plural snake case.
+     */
+    pluralize?: boolean;
+
+    /**
+     * A set of irregular plurals to use when converting
+     * to plural snake case. Both the singular and plural
+     * forms should already be in snake case.
+     */
+    irregularPlurals?: Record<string, string>;
   } = {},
 ): string {
   const { trimPrefix = '', compoundWords = [] } = options;
@@ -39,5 +53,15 @@ export function toSnakeCase(
       acc.replace(compoundWord, compoundWord.replace(/_/g, '')),
     snakeCase,
   );
+  if (options.pluralize) {
+    if (options.irregularPlurals) {
+      for (const [singular, plural] of Object.entries(
+        options.irregularPlurals,
+      )) {
+        pluralize.addIrregularRule(singular, plural);
+      }
+    }
+    return pluralize(snakeCaseWithCompoundWords);
+  }
   return snakeCaseWithCompoundWords;
 }

--- a/src/common/snake-case.ts
+++ b/src/common/snake-case.ts
@@ -28,9 +28,10 @@ export function toSnakeCase(
     pluralize?: boolean;
 
     /**
-     * A set of irregular plurals to use when converting
-     * to plural snake case. Both the singular and plural
-     * forms should already be in snake case.
+     * A mapping from singular form to irregular plural form,
+     * for use when `pluralize` is true. Both forms should be
+     * in snake case.
+     * Example: `{ bill_of_lading: "bills_of_lading" }`
      */
     irregularPlurals?: Record<string, string>;
   } = {},

--- a/src/rules/model-name-mapping-snake-case.test.ts
+++ b/src/rules/model-name-mapping-snake-case.test.ts
@@ -97,15 +97,15 @@ describe('model-name-mapping-snake-case', () => {
   describe('expecting irregular plural names', () => {
     const run = getRunner({
       pluralize: true,
-      irregularPlurals: { qux: 'quxora' },
+      irregularPlurals: { bill_of_lading: 'bills_of_lading' },
     });
 
     describe('with a plural name', () => {
       it('returns no violations', async () => {
         const violations = await run(`
-      model Qux {
+      model BillOfLading {
         id String @id
-        @@map(name: "quxora")
+        @@map(name: "bills_of_lading")
       }
     `);
         expect(violations.length).toEqual(0);
@@ -115,9 +115,9 @@ describe('model-name-mapping-snake-case', () => {
     describe('with a singular name', () => {
       it('returns violation', async () => {
         const violations = await run(`
-      model Qux {
+      model BillOfLading {
         id String @id
-        @@map(name: "qux")
+        @@map(name: "bill_of_lading")
       }
     `);
         expect(violations.length).toEqual(1);

--- a/src/rules/model-name-mapping-snake-case.test.ts
+++ b/src/rules/model-name-mapping-snake-case.test.ts
@@ -65,4 +65,63 @@ describe('model-name-mapping-snake-case', () => {
       });
     });
   });
+
+  describe('expecting plural names', () => {
+    const run = getRunner({ pluralize: true });
+
+    describe('with a plural name', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      model UserRole {
+        id String @id
+        @@map(name: "user_roles")
+      }
+    `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('with a singular name', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+      model UserRole {
+        id String @id
+        @@map(name: "user_role")
+      }
+    `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+  });
+
+  describe('expecting irregular plural names', () => {
+    const run = getRunner({
+      pluralize: true,
+      irregularPlurals: { qux: 'quxora' },
+    });
+
+    describe('with a plural name', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      model Qux {
+        id String @id
+        @@map(name: "quxora")
+      }
+    `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('with a singular name', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+      model Qux {
+        id String @id
+        @@map(name: "qux")
+      }
+    `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+  });
 });

--- a/src/rules/model-name-mapping-snake-case.ts
+++ b/src/rules/model-name-mapping-snake-case.ts
@@ -12,6 +12,8 @@ const Config = z
   .object({
     compoundWords: z.array(z.string()).optional(),
     trimPrefix: z.string().optional(),
+    pluralize: z.boolean().optional(),
+    irregularPlurals: z.record(z.string()).optional(),
   })
   .strict()
   .optional();
@@ -64,6 +66,24 @@ const Config = z
  *     @@map(name: "graph_q_l_persisted_query")
  *   }
  *
+ * 
+ * @example { pluralize: true }
+ *   // good
+ *   model UserRole {
+ *     id String @id
+ *     @@map(name: "user_roles")
+ *   }
+ *
+ *   // bad
+ *   model UserRole {
+ *     id String @id
+ *   }
+ *
+ *   model UserRole {
+ *     id String @id
+ *     @@map(name: "user_role")
+ *   }
+ *
  */
 export default {
   ruleName: RULE_NAME,
@@ -71,6 +91,8 @@ export default {
   create: (config, context) => {
     const compoundWords = config?.compoundWords ?? [];
     const trimPrefix = config?.trimPrefix ?? '';
+    const shouldPluralize = config?.pluralize ?? false;
+    const irregularPlurals = config?.irregularPlurals ?? {};
     return {
       Model: (model) => {
         const attributes = listAttributes(model);
@@ -94,6 +116,8 @@ export default {
         const expectedSnakeCase = toSnakeCase(nodeName, {
           compoundWords,
           trimPrefix,
+          pluralize: shouldPluralize,
+          irregularPlurals,
         });
         if (mappedName !== expectedSnakeCase) {
           context.report({


### PR DESCRIPTION
Great tool!

I'm working with a database where the table names are in plural snake case, but the Prisma model names are in singular pascal case, and I'd like to add a lint for that.

I've updated the `model-name-mapping-snake-case` rule to accept two new options: `pluralize`, and `irregularPlurals`. The pluralization is done by the `pluralize` library that is already being used elsewhere.

The only caveat is that calls to `pluralize.addIrregularRule` affect the global ruleset, so will apply elsewhere, but unfortunately that appears to be a limitation of the library (https://github.com/plurals/pluralize/issues/25, https://github.com/plurals/pluralize/issues/87).