### PR TITLE
[M] Add `requireUnderscorePrefixForIds` and remove `requirePrefix` to actually support Mongo naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#330](https://github.com/loop-payments/prisma-lint/issues/330) Remove `requirePrefix` option and add `requireUnderscorePrefixForIds` to `field-name-mapping-snake-case` to actually support MongoDB naming conventions. 
+
 ## 0.2.0 (2024-03-29)
 
 - [#354](https://github.com/loop-payments/prisma-lint/issues/354) Add `allowlist` to `model-name-grammatical-number`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.0 (2024-04-03)
+
 - [#330](https://github.com/loop-payments/prisma-lint/issues/330) Remove `requirePrefix` option and add `requireUnderscorePrefixForIds` to `field-name-mapping-snake-case` to actually support MongoDB naming conventions. 
 
 ## 0.2.0 (2024-03-29)

--- a/RULES.md
+++ b/RULES.md
@@ -70,7 +70,7 @@ model PersistedQuery {
 }
 ```
 
-#### With `{ requireUnderscorePrefixForId: true }`
+#### With `{ requireUnderscorePrefixForIds: true }`
 
 ```prisma
 // good

--- a/RULES.md
+++ b/RULES.md
@@ -25,7 +25,7 @@ Checks that the mapped name of a field is the expected snake case.
 ```ts
 z.object({
   compoundWords: z.array(z.string()).optional(),
-  requirePrefix: z.string().optional(),
+  requireUnderscorePrefixForIds: z.boolean().optional(),
 })
   .strict()
   .optional();
@@ -70,17 +70,19 @@ model PersistedQuery {
 }
 ```
 
-#### With `{ requirePrefix: ["_"] }`
+#### With `{ requireUnderscorePrefixForId: ["_"] }`
 
 ```prisma
 // good
 model PersistedQuery {
-  fooId String @map(name: "_foo_id")
+  id String @id @map(name: "_id")
+  otherField String @map(name: "other_field")
 }
 
 // bad
 model PersistedQuery {
-  fooId String @map(name: "foo_id")
+  id String @id @map(name: "id")
+  otherField String @map(name: "other_field")
 }
 ```
 

--- a/RULES.md
+++ b/RULES.md
@@ -70,7 +70,7 @@ model PersistedQuery {
 }
 ```
 
-#### With `{ requireUnderscorePrefixForId: ["_"] }`
+#### With `{ requireUnderscorePrefixForId: true }`
 
 ```prisma
 // good

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-lint",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A linter for Prisma schema files.",
   "repository": {
     "type": "git",

--- a/src/rules/field-name-mapping-snake-case.test.ts
+++ b/src/rules/field-name-mapping-snake-case.test.ts
@@ -15,17 +15,18 @@ describe('field-name-mapping-snake-case', () => {
       ruleDefinitions: [fieldNameMappingSnakeCase],
     });
 
-  describe('with requirePrefix', () => {
-    const run = getRunner({ requirePrefix: '_' });
+  describe('with requireUnderscorePrefixForId', () => {
+    const run = getRunner({ requireUnderscorePrefixForIds: true });
 
     describe('valid with mapping', () => {
       it('returns no violations', async () => {
         const violations = await run(`
       model User {
-        fooBar String @map(name: "_foo_bar")
+        id String @id @map(name: "_id")
+        otherField String @map(name: "other_field")
       }
     `);
-        expect(violations.length).toEqual(0);
+        expect(violations.map((v) => v.message)).toEqual([]);
       });
     });
 
@@ -33,10 +34,10 @@ describe('field-name-mapping-snake-case', () => {
       it('returns violation', async () => {
         const violations = await run(`
       model User {
-        fooBar String
+        idFoo String @id
       }
     `);
-        expect(violations.length).toEqual(1);
+        expect(violations).toHaveLength(1);
       });
     });
 
@@ -44,7 +45,20 @@ describe('field-name-mapping-snake-case', () => {
       it('returns violation', async () => {
         const violations = await run(`
       model user {
-        fooBar String @map(name: "foo_bar")
+        id String @id @map(name: "id")
+      }
+    `);
+        expect(violations.map((v) => v.message)).toEqual([
+          'Field name must be mapped to "_id".',
+        ]);
+      });
+    });
+
+    describe('with wrong mapping', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+      model user {
+        idTwo String @id @map(name: "_id_one")
       }
     `);
         expect(violations.length).toEqual(1);

--- a/src/rules/field-name-mapping-snake-case.test.ts
+++ b/src/rules/field-name-mapping-snake-case.test.ts
@@ -15,7 +15,7 @@ describe('field-name-mapping-snake-case', () => {
       ruleDefinitions: [fieldNameMappingSnakeCase],
     });
 
-  describe('with requireUnderscorePrefixForId', () => {
+  describe('with requireUnderscorePrefixForIds', () => {
     const run = getRunner({ requireUnderscorePrefixForIds: true });
 
     describe('valid with mapping', () => {

--- a/src/rules/field-name-mapping-snake-case.ts
+++ b/src/rules/field-name-mapping-snake-case.ts
@@ -51,7 +51,7 @@ const Config = z
  *     graphQLId String @map(name: "graph_q_l_id")
  *   }
  *
- * @example { requireUnderscorePrefixForId: ["_"] }
+ * @example { requireUnderscorePrefixForId: true }
  *   // good
  *   model PersistedQuery {
  *     id String @id @map(name: "_id")

--- a/src/rules/field-name-mapping-snake-case.ts
+++ b/src/rules/field-name-mapping-snake-case.ts
@@ -51,7 +51,7 @@ const Config = z
  *     graphQLId String @map(name: "graph_q_l_id")
  *   }
  *
- * @example { requireUnderscorePrefixForId: true }
+ * @example { requireUnderscorePrefixForIds: true }
  *   // good
  *   model PersistedQuery {
  *     id String @id @map(name: "_id")


### PR DESCRIPTION
Actually fixes https://github.com/loop-payments/prisma-lint/issues/330