### PR TITLE
add new rule 'ban-unbounded-string-type'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new rule `ban-unbounded-string-type`
+
 ## 0.5.0 (2024-05-01)
 
 - [#388](https://github.com/loop-payments/prisma-lint/issues/388) Teach `field-name-mapping-snake-case` ignore comments about individual fields.

--- a/RULES.md
+++ b/RULES.md
@@ -4,6 +4,7 @@
 
 Configuration option schemas are written with [Zod](https://github.com/colinhacks/zod).
 
+- [ban-unbounded-string-type](#ban-unbounded-string-type)
 - [field-name-mapping-snake-case](#field-name-mapping-snake-case)
 - [field-order](#field-order)
 - [forbid-field](#forbid-field)
@@ -15,6 +16,51 @@ Configuration option schemas are written with [Zod](https://github.com/colinhack
 - [require-field-index](#require-field-index)
 - [require-field-type](#require-field-type)
 - [require-field](#require-field)
+
+## ban-unbounded-string-type
+
+Checks that String fields are defined with a database native type to
+limit the length, e.g. `@db.VarChar(x)`.
+Motivation inspired by https://brandur.org/text - to avoid unintentionally
+building public APIs that support unlimited-length strings.
+
+### Configuration
+
+```ts
+z.object({
+  allowNativeTextType: z.boolean().optional(),
+}).strict();
+```
+
+### Examples
+
+#### Default
+
+```prisma
+// good
+model User {
+  id String @db.VarChar(36)
+}
+
+// bad
+model User {
+  id String
+}
+
+// bad
+model User {
+ id String @db.Text
+}
+```
+
+#### With `{ allowNativeTextType: true }`
+
+```prisma
+// good
+model User {
+  id String @db.Text
+}
+```
 
 ## field-name-mapping-snake-case
 

--- a/src/rule-definitions.ts
+++ b/src/rule-definitions.ts
@@ -1,4 +1,5 @@
 import type { RuleDefinition } from '#src/common/rule.js';
+import banUnboundedStringType from '#src/rules/ban-unbounded-string-type.js';
 import fieldNameMappingSnakeCase from '#src/rules/field-name-mapping-snake-case.js';
 import fieldOrder from '#src/rules/field-order.js';
 import forbidField from '#src/rules/forbid-field.js';
@@ -12,6 +13,7 @@ import requireFieldType from '#src/rules/require-field-type.js';
 import requireField from '#src/rules/require-field.js';
 
 export default [
+  banUnboundedStringType,
   fieldNameMappingSnakeCase,
   fieldOrder,
   forbidField,

--- a/src/rules/ban-unbounded-string-type.test.ts
+++ b/src/rules/ban-unbounded-string-type.test.ts
@@ -1,0 +1,71 @@
+import type { RuleConfig } from '#src/common/config.js';
+import { testLintPrismaSource } from '#src/common/test.js';
+import banUnboundedStringType from '#src/rules/ban-unbounded-string-type.js';
+
+describe('ban-unbounded-string-type', () => {
+  const getRunner = (config?: RuleConfig) => async (sourceCode: string) =>
+    await testLintPrismaSource({
+      fileName: 'fake.ts',
+      sourceCode,
+      rootConfig: {
+        rules: {
+          'ban-unbounded-string-type': ['error', config],
+        },
+      },
+      ruleDefinitions: [banUnboundedStringType],
+    });
+
+  describe('empty config', () => {
+    const run = getRunner();
+
+    describe('bounded string type', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      model User {
+        id String @db.VarChar(36)
+      }
+    `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('unbounded string type', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+      model Users {
+        id String 
+      }
+    `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+
+    describe('native @db.Text type without override', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+        model Users {
+          id String @db.Text
+        }
+      `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+  });
+
+  describe('allow native @db.Text type', () => {
+    const run = getRunner({
+      allowNativeTextType: true,
+    });
+
+    describe('@db.Text type permitted', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      model User {
+        id String @db.Text
+      }
+    `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+  });
+});

--- a/src/rules/ban-unbounded-string-type.ts
+++ b/src/rules/ban-unbounded-string-type.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import type { FieldRuleDefinition } from '#src/common/rule.js';
+
+const RULE_NAME = 'ban-unbounded-string-type';
+
+const Config = z
+  .object({
+    allowNativeTextType: z.boolean().optional(),
+  })
+  .strict();
+
+/**
+ * Checks that String fields are defined with a database native type to
+ * limit the length, e.g. `@db.VarChar(x)`.
+ * Motivation inspired by https://brandur.org/text - to avoid unintentionally
+ * building public APIs that support unlimited-length strings.
+ *
+ * @example
+ *   // good
+ *   model User {
+ *     id String @db.VarChar(36)
+ *   }
+ *
+ *   // bad
+ *   model User {
+ *     id String
+ *   }
+ *
+ *   // bad
+ *   model User {
+ *    id String @db.Text
+ *   }
+ *
+ * @example { allowNativeTextType: true }
+ *   // good
+ *   model User {
+ *     id String @db.Text
+ *   }
+ *
+ */
+export default {
+  ruleName: RULE_NAME,
+  configSchema: Config,
+  create: (config, context) => {
+    const { allowNativeTextType } = config;
+    return {
+      Field: (model, field) => {
+        if (field.fieldType !== 'String') {
+          return;
+        }
+
+        const nativeTypeAttribute = field.attributes?.find(
+          (attr) => attr.group === 'db',
+        );
+
+        if (
+          !nativeTypeAttribute ||
+          (nativeTypeAttribute.name === 'Text' && !allowNativeTextType)
+        ) {
+          const message =
+            'String fields must have a native type attribute to ensure maximum length, e.g. `@db.VarChar(x)`.';
+          context.report({ model, field, message });
+        }
+      },
+    };
+  },
+} satisfies FieldRuleDefinition<z.infer<typeof Config>>;


### PR DESCRIPTION
(For Postgres) - ensure bounded `@db.VarChar(x)` database-native types provided for `String` fields rather than defaulting to `@db.Text`.

Inspired by https://brandur.org/text - to guard against building public-facing APIs that accept unlimited-length strings and have to clean up later.