### PR TITLE
Add support for Enums, with new rules `enum-name-pascal-case` and `enum-value-snake-case`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new rules `enum-name-pascal-case` and `enum-value-snake-case`
+
 ## 0.5.0 (2024-05-01)
 
 - [#388](https://github.com/loop-payments/prisma-lint/issues/388) Teach `field-name-mapping-snake-case` ignore comments about individual fields.

--- a/RULES.md
+++ b/RULES.md
@@ -4,6 +4,8 @@
 
 Configuration option schemas are written with [Zod](https://github.com/colinhacks/zod).
 
+- [enum-name-pascal-case](#enum-name-pascal-case)
+- [enum-value-snake-case](#enum-value-snake-case)
 - [field-name-mapping-snake-case](#field-name-mapping-snake-case)
 - [field-order](#field-order)
 - [forbid-field](#forbid-field)
@@ -15,6 +17,96 @@ Configuration option schemas are written with [Zod](https://github.com/colinhack
 - [require-field-index](#require-field-index)
 - [require-field-type](#require-field-type)
 - [require-field](#require-field)
+
+## enum-name-pascal-case
+
+Checks that enum names are in PascalCase.
+
+### Configuration
+
+```ts
+z.object({
+  allowList: z.array(z.union([z.string(), z.instanceof(RegExp)])).optional(),
+  trimPrefix: z
+    .union([
+      z.string(),
+      z.instanceof(RegExp),
+      z.array(z.union([z.string(), z.instanceof(RegExp)])),
+    ])
+    .optional(),
+}).strict();
+```
+
+### Examples
+
+#### Default
+
+```prisma
+// good
+enum ExampleOptions {
+  value1
+}
+
+// bad
+enum exampleOptions {
+  value1
+}
+
+// bad
+enum example_options {
+ value1
+}
+```
+
+## enum-value-snake-case
+
+Checks that enum values are in snake_case.
+
+### Configuration
+
+```ts
+z.object({
+  allowList: z.array(z.union([z.string(), z.instanceof(RegExp)])).optional(),
+  trimPrefix: z
+    .union([
+      z.string(),
+      z.instanceof(RegExp),
+      z.array(z.union([z.string(), z.instanceof(RegExp)])),
+    ])
+    .optional(),
+}).strict();
+```
+
+### Examples
+
+#### Default
+
+```prisma
+// good
+enum Example {
+  value
+}
+
+// good
+enum Example {
+  value_1
+}
+
+// bad
+enum Example {
+  Value
+}
+
+// bad
+enum Example {
+  VALUE
+}
+
+// bad
+enum Example {
+  camelCase
+}
+```
 
 ## field-name-mapping-snake-case
 

--- a/src/common/ignore.ts
+++ b/src/common/ignore.ts
@@ -41,12 +41,15 @@ export function isRuleEntirelyIgnored(
   );
 }
 
-export function getRuleIgnoreParams(model: Model, ruleName: string) {
-  const ignoreModelComments = listIgnoreModelComments(model);
-  const ruleIgnoreComment = ignoreModelComments.find(
-    (c) =>
-      c.startsWith(`${IGNORE_MODEL} ${ruleName} `) ||
-      c.startsWith(`${IGNORE_ENUM} ${ruleName} `),
+export function getRuleIgnoreParams(node: Model | Enum, ruleName: string) {
+  const ignoreComments =
+    node.type === 'model'
+      ? listIgnoreModelComments(node)
+      : listIgnoreEnumComments(node);
+  const ruleIgnoreComment = ignoreComments.find((c) =>
+    c.startsWith(
+      `${node.type === 'model' ? IGNORE_MODEL : IGNORE_ENUM} ${ruleName} `,
+    ),
   );
   if (ruleIgnoreComment == null) {
     return [];

--- a/src/common/ignore.ts
+++ b/src/common/ignore.ts
@@ -1,8 +1,9 @@
-import type { Model } from '@mrleebo/prisma-ast';
+import type { Enum, Model } from '@mrleebo/prisma-ast';
 
 import { PrismaPropertyType } from '#src/common/prisma.js';
 
 const IGNORE_MODEL = '/// prisma-lint-ignore-model';
+const IGNORE_ENUM = '/// prisma-lint-ignore-enum';
 
 export function listIgnoreModelComments(node: Model) {
   const commentFields = node.properties.filter(
@@ -13,21 +14,39 @@ export function listIgnoreModelComments(node: Model) {
     .filter((t) => t.startsWith(IGNORE_MODEL));
 }
 
-export function isModelEntirelyIgnored(ignoreModelComments: string[]) {
-  return ignoreModelComments.includes(IGNORE_MODEL);
+export function listIgnoreEnumComments(node: Enum) {
+  const commentFields = node.enumerators.filter(
+    (enumerator) => enumerator.type === 'comment',
+  );
+  return commentFields
+    .map((f) => f.text.trim())
+    .filter((t) => t.startsWith(IGNORE_ENUM));
+}
+
+export function isModelEntirelyIgnored(ignoreComments: string[]) {
+  return ignoreComments.includes(IGNORE_MODEL);
+}
+
+export function isEnumEntirelyIgnored(ignoreComments: string[]) {
+  return ignoreComments.includes(IGNORE_ENUM);
 }
 
 export function isRuleEntirelyIgnored(
   ruleName: string,
   ignoreModelComments: string[],
 ) {
-  return ignoreModelComments.includes(`${IGNORE_MODEL} ${ruleName}`);
+  return (
+    ignoreModelComments.includes(`${IGNORE_MODEL} ${ruleName}`) ||
+    ignoreModelComments.includes(`${IGNORE_ENUM} ${ruleName}`)
+  );
 }
 
 export function getRuleIgnoreParams(model: Model, ruleName: string) {
   const ignoreModelComments = listIgnoreModelComments(model);
-  const ruleIgnoreComment = ignoreModelComments.find((c) =>
-    c.startsWith(`${IGNORE_MODEL} ${ruleName} `),
+  const ruleIgnoreComment = ignoreModelComments.find(
+    (c) =>
+      c.startsWith(`${IGNORE_MODEL} ${ruleName} `) ||
+      c.startsWith(`${IGNORE_ENUM} ${ruleName} `),
   );
   if (ruleIgnoreComment == null) {
     return [];

--- a/src/common/rule.ts
+++ b/src/common/rule.ts
@@ -1,9 +1,10 @@
-import type { Field, Model } from '@mrleebo/prisma-ast';
+import type { Enum, Field, Model } from '@mrleebo/prisma-ast';
 
 import type { z } from 'zod';
 
 import type { RuleConfig } from '#src/common/config.js';
 import type {
+  EnumViolation,
   FieldViolation,
   ModelViolation,
   NodeViolation,
@@ -48,7 +49,21 @@ export type FieldRuleInstance = {
   Field: (model: Model, field: Field) => void;
 };
 
+export type EnumRuleDefinition<T> = {
+  ruleName: string;
+  configSchema: z.ZodSchema<T>;
+  create: (config: T, context: RuleContext<EnumViolation>) => EnumRuleInstance;
+};
+
+export type EnumRuleInstance = {
+  Enum: (enumObj: Enum) => void;
+};
+
 export type RuleDefinition =
   | ModelRuleDefinition<any>
-  | FieldRuleDefinition<any>;
-export type RuleInstance = ModelRuleInstance | FieldRuleInstance;
+  | FieldRuleDefinition<any>
+  | EnumRuleDefinition<any>;
+export type RuleInstance =
+  | ModelRuleInstance
+  | FieldRuleInstance
+  | EnumRuleInstance;

--- a/src/common/violation.ts
+++ b/src/common/violation.ts
@@ -1,17 +1,27 @@
-import type { Field, Model } from '@mrleebo/prisma-ast';
+import type { Enum, Field, Model } from '@mrleebo/prisma-ast';
 
+export type EnumViolation = { enum: Enum; message: string };
 export type ModelViolation = { model: Model; message: string };
 export type FieldViolation = {
   model: Model;
   field: Field;
   message: string;
 };
-export type NodeViolation = ModelViolation | FieldViolation;
+export type NodeViolation = EnumViolation | ModelViolation | FieldViolation;
 
 export type Violation = {
   ruleName: string;
   fileName: string;
-  model: Model;
-  field?: Field;
   message: string;
-};
+} & (
+  | {
+      model: Model;
+      field?: Field;
+      enum?: undefined;
+    }
+  | {
+      model?: undefined;
+      field?: undefined;
+      enum: Enum;
+    }
+);

--- a/src/lint-prisma-source-code.ts
+++ b/src/lint-prisma-source-code.ts
@@ -3,6 +3,8 @@ import {
   isModelEntirelyIgnored,
   isRuleEntirelyIgnored,
   listIgnoreModelComments,
+  listIgnoreEnumComments,
+  isEnumEntirelyIgnored,
 } from '#src/common/ignore.js';
 import {
   listModelBlocks,
@@ -72,6 +74,20 @@ export function lintPrismaSourceCode({
           fields.forEach((field) => {
             ruleInstance.Field(model, field);
           });
+        }
+      });
+  });
+
+  enums.forEach((enumObj) => {
+    const comments = listIgnoreEnumComments(enumObj);
+    if (isEnumEntirelyIgnored(comments)) {
+      return;
+    }
+    namedRuleInstances
+      .filter(({ ruleName }) => !isRuleEntirelyIgnored(ruleName, comments))
+      .forEach(({ ruleInstance }) => {
+        if ('Enum' in ruleInstance) {
+          ruleInstance.Enum(enumObj);
         }
       });
   });

--- a/src/output/render/render-contextual.ts
+++ b/src/output/render/render-contextual.ts
@@ -11,7 +11,8 @@ export const renderViolationsContextual = (
   const lines = pairs.flatMap(([key, violations]) => {
     const first = violations[0];
     const { fileName } = first;
-    const rawLocation = first.field?.location ?? first.model.location;
+    const rawLocation =
+      first.field?.location ?? first.model?.location ?? first.enum?.location;
     if (!rawLocation) {
       throw new Error('No location');
     }

--- a/src/output/render/render-json.ts
+++ b/src/output/render/render-json.ts
@@ -13,7 +13,8 @@ export const renderViolationsJsonObject = (
   return pairs.flatMap(([_, violations]) => {
     const first = violations[0];
     const { fileName } = first;
-    const rawLocation = first.field?.location ?? first.model.location;
+    const rawLocation =
+      first.field?.location ?? first.model?.location ?? first.enum?.location;
     if (!rawLocation) {
       throw new Error('No location');
     }

--- a/src/output/render/render-simple.ts
+++ b/src/output/render/render-simple.ts
@@ -7,7 +7,8 @@ export const renderViolationsSimple = (violations: Violation[]): string[] => {
   const pairs = keyViolationListPairs(violations);
   return pairs.flatMap(([key, violations]) => {
     const first = violations[0];
-    const location = first.field?.location ?? first.model.location;
+    const location =
+      first.field?.location ?? first.model?.location ?? first.enum?.location;
     if (!location) {
       throw new Error('No location');
     }

--- a/src/output/render/render-util.ts
+++ b/src/output/render/render-util.ts
@@ -5,8 +5,12 @@ export const keyViolationListPairs = (
 ): [string, Violation[]][] => {
   const groupedByKey = violations.reduce(
     (acc, violation) => {
-      const { model, field } = violation;
-      const key = field ? `${model.name}.${field.name}` : model.name;
+      const { model, field, enum: enumObj } = violation;
+      const key = field
+        ? `${model.name}.${field.name}`
+        : enumObj
+          ? enumObj.name
+          : model.name;
       const violations = acc[key] ?? [];
       return { ...acc, [key]: [...violations, violation] };
     },

--- a/src/rule-definitions.ts
+++ b/src/rule-definitions.ts
@@ -1,4 +1,6 @@
 import type { RuleDefinition } from '#src/common/rule.js';
+import enumNamePascalCase from '#src/rules/enum-name-pascal-case.js';
+import enumValueSnakeCase from '#src/rules/enum-value-snake-case.js';
 import fieldNameMappingSnakeCase from '#src/rules/field-name-mapping-snake-case.js';
 import fieldOrder from '#src/rules/field-order.js';
 import forbidField from '#src/rules/forbid-field.js';
@@ -12,6 +14,8 @@ import requireFieldType from '#src/rules/require-field-type.js';
 import requireField from '#src/rules/require-field.js';
 
 export default [
+  enumNamePascalCase,
+  enumValueSnakeCase,
   fieldNameMappingSnakeCase,
   fieldOrder,
   forbidField,

--- a/src/rules/enum-name-pascal-case.test.ts
+++ b/src/rules/enum-name-pascal-case.test.ts
@@ -1,0 +1,219 @@
+import type { RuleConfig } from '#src/common/config.js';
+import { testLintPrismaSource } from '#src/common/test.js';
+import enumNamePascalCase from '#src/rules/enum-name-pascal-case.js';
+
+describe('enum-name-pascal-case', () => {
+  const getRunner = (config?: RuleConfig) => async (sourceCode: string) =>
+    await testLintPrismaSource({
+      fileName: 'fake.ts',
+      sourceCode,
+      rootConfig: {
+        rules: {
+          'enum-name-pascal-case': ['error', config],
+        },
+      },
+      ruleDefinitions: [enumNamePascalCase],
+    });
+
+  describe('ignore comments', () => {
+    const run = getRunner();
+
+    it('respects rule-specific ignore comments', async () => {
+      const violations = await run(`
+    enum exampleOptions {
+      /// prisma-lint-ignore-enum enum-name-pascal-case
+      value1
+    }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('respects model-wide ignore comments', async () => {
+      const violations = await run(`
+    enum exampleOptions {
+      /// prisma-lint-ignore-enum
+      value1
+    }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+  });
+
+  describe('without config', () => {
+    const run = getRunner();
+
+    describe('single word', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      enum Example {
+        value1
+      }
+    `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('compound word in PascalCase', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      enum ExampleOptions {
+        value1
+      }
+    `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('first character is not uppercase', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+      enum exampleOptions {
+        value1
+      }
+      `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+
+    describe('contains underscore', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+      enum example_options {
+        value1
+      }
+      `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+
+    describe('permits digits anywhere', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+      enum Exampl3O0ptions {
+        value1
+      }
+      `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+  });
+
+  describe('with allowlist string', () => {
+    const run = getRunner({ allowList: ['exampleOptions'] });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+    enum exampleOptions {
+      value1
+    }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('allowList string requires full match', async () => {
+      const violations = await run(`
+      enum exampleOptionsWithSuffix {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+
+  describe('with allowlist regexp', () => {
+    const run = getRunner({ allowList: [/^db.*/] });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+      enum db_exampleOptions {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+  });
+
+  describe('with trimPrefix single string', () => {
+    const run = getRunner({ trimPrefix: 'db' });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+      enum dbExampleOptions {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('remaining suffix must be PascalCase', async () => {
+      const violations = await run(`
+      enum dbcamelCase {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+
+  describe('with trimPrefix single regexp', () => {
+    const run = getRunner({ trimPrefix: /^db/ });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+      enum dbExampleOptions {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('remaining suffix must be PascalCase', async () => {
+      const violations = await run(`
+      enum dbcamelCase {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+
+  describe('with trimPrefix array', () => {
+    const run = getRunner({ trimPrefix: ['db', /^eg/] });
+
+    it('returns no violations for first prefix', async () => {
+      const violations = await run(`
+      enum dbExampleOptions {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('returns no violations for second prefix', async () => {
+      const violations = await run(`
+      enum egExampleOptions {
+        value1
+      }
+      `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('remaining suffix after string must be PascalCase', async () => {
+      const violations = await run(`
+      enum dbexampleOptions {
+        value1
+      }
+    `);
+      expect(violations.length).toEqual(1);
+    });
+
+    it('remaining suffix after regexp must be PascalCase', async () => {
+      const violations = await run(`
+      enum egexampleOptions {
+        value1
+      }
+      `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+});

--- a/src/rules/enum-name-pascal-case.ts
+++ b/src/rules/enum-name-pascal-case.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+import {
+  matchesAllowList,
+  trimPrefix,
+} from '#src/common/rule-config-helpers.js';
+import type { EnumRuleDefinition } from '#src/common/rule.js';
+
+const RULE_NAME = 'enum-name-pascal-case';
+
+const Config = z
+  .object({
+    allowList: z.array(z.union([z.string(), z.instanceof(RegExp)])).optional(),
+    trimPrefix: z
+      .union([
+        z.string(),
+        z.instanceof(RegExp),
+        z.array(z.union([z.string(), z.instanceof(RegExp)])),
+      ])
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Checks that enum names are in PascalCase.
+ *
+ * @example
+ *   // good
+ *   enum ExampleOptions {
+ *     value1
+ *   }
+ *
+ *   // bad
+ *   enum exampleOptions {
+ *     value1
+ *   }
+ *
+ *   // bad
+ *   enum example_options {
+ *    value1
+ *   }
+ *
+ */
+export default {
+  ruleName: RULE_NAME,
+  configSchema: Config,
+  create: (config, context) => {
+    const { allowList, trimPrefix: trimPrefixConfig } = config;
+    return {
+      Enum: (enumObj) => {
+        if (matchesAllowList(enumObj.name, allowList)) {
+          return;
+        }
+        const nameWithoutPrefix = trimPrefix(enumObj.name, trimPrefixConfig);
+        if (!nameWithoutPrefix.match(/^[A-Z][a-zA-Z0-9]*$/)) {
+          const message = 'Enum name should be in PascalCase.';
+          context.report({ enum: enumObj, message });
+        }
+      },
+    };
+  },
+} satisfies EnumRuleDefinition<z.infer<typeof Config>>;

--- a/src/rules/enum-value-snake-case.test.ts
+++ b/src/rules/enum-value-snake-case.test.ts
@@ -1,0 +1,230 @@
+import type { RuleConfig } from '#src/common/config.js';
+import { testLintPrismaSource } from '#src/common/test.js';
+import enumValueSnakeCase from '#src/rules/enum-value-snake-case.js';
+
+describe('enum-value-snake-case', () => {
+  const getRunner = (config?: RuleConfig) => async (sourceCode: string) =>
+    await testLintPrismaSource({
+      fileName: 'fake.ts',
+      sourceCode,
+      rootConfig: {
+        rules: {
+          'enum-value-snake-case': ['error', config],
+        },
+      },
+      ruleDefinitions: [enumValueSnakeCase],
+    });
+
+  describe('ignore comments', () => {
+    const run = getRunner();
+
+    it('respects rule-specific ignore comments', async () => {
+      const violations = await run(`
+        enum Example {
+          /// prisma-lint-ignore-enum enum-value-snake-case
+          PascalCase
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('respects model-wide ignore comments', async () => {
+      const violations = await run(`
+        enum Example {
+          /// prisma-lint-ignore-enum
+          PascalCase
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+  });
+
+  describe('without config', () => {
+    const run = getRunner();
+
+    describe('single lowercase word', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+          enum Example {
+            value
+          }
+        `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('digit requires underscore', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+            enum Example {
+              value1
+            }
+          `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+
+    describe('digit allowed after underscore', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+              enum Example {
+                value_1
+              }
+            `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+
+    describe('compound word in PascalCase', () => {
+      it('returns violations', async () => {
+        const violations = await run(`
+          enum Example {
+            ExampleValue
+          }
+        `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+
+    describe('first character is uppercase', () => {
+      it('returns violation', async () => {
+        const violations = await run(`
+          enum Example {
+            Value
+          }
+          `);
+        expect(violations.length).toEqual(1);
+      });
+    });
+
+    describe('compound word in valid snake case', () => {
+      it('returns no violations', async () => {
+        const violations = await run(`
+          enum Example {
+            example_option
+          }
+          `);
+        expect(violations.length).toEqual(0);
+      });
+    });
+  });
+
+  describe('with allowlist string', () => {
+    const run = getRunner({ allowList: ['exampleOptions'] });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+        enum Example {
+          exampleOptions
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('allowList string requires full match', async () => {
+      const violations = await run(`
+        enum Example {
+          exampleOptionsWithSuffix
+        }
+        `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+
+  describe('with allowlist regexp', () => {
+    const run = getRunner({ allowList: [/^DB.*/] });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+        enum Example {
+          DBexample_options
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+  });
+
+  describe('with trimPrefix single string', () => {
+    const run = getRunner({ trimPrefix: 'DB' });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+        enum Example {
+          DBexample_options
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('remaining suffix must be snake_case', async () => {
+      const violations = await run(`
+        enum Example {
+          dbExampleOptions
+        }
+        `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+
+  describe('with trimPrefix single regexp', () => {
+    const run = getRunner({ trimPrefix: /^DB/ });
+
+    it('returns no violations', async () => {
+      const violations = await run(`
+        enum Example {
+          DBexample_options
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('remaining suffix must be snake_case', async () => {
+      const violations = await run(`
+        enum Example {
+          DBexampleOptions
+        }
+        `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+
+  describe('with trimPrefix array', () => {
+    const run = getRunner({ trimPrefix: ['DB', /^EG/] });
+
+    it('returns no violations for first prefix', async () => {
+      const violations = await run(`
+        enum Example {
+          DBexample_options
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('returns no violations for second prefix', async () => {
+      const violations = await run(`
+        enum Example {
+          EGexample_options
+        }
+          `);
+      expect(violations.length).toEqual(0);
+    });
+
+    it('remaining suffix after string must be snake_case', async () => {
+      const violations = await run(`
+        enum Example {
+          DBexampleOptions
+        }
+        `);
+      expect(violations.length).toEqual(1);
+    });
+
+    it('remaining suffix after regexp must be snake_case', async () => {
+      const violations = await run(`
+        enum Example {
+          EGexampleOptions
+        }
+          `);
+      expect(violations.length).toEqual(1);
+    });
+  });
+});

--- a/src/rules/enum-value-snake-case.test.ts
+++ b/src/rules/enum-value-snake-case.test.ts
@@ -37,6 +37,20 @@ describe('enum-value-snake-case', () => {
         `);
       expect(violations.length).toEqual(0);
     });
+
+    it('respects parametised field ignore comments', async () => {
+      const violations = await run(`
+          enum Example {
+            /// prisma-lint-ignore-enum enum-value-snake-case InvalidTwo,InvalidThree
+            valid_one
+            InvalidTwo
+            InvalidThree
+            InvalidFour
+            InvalidFive
+          }
+          `);
+      expect(violations.length).toEqual(2);
+    });
   });
 
   describe('without config', () => {

--- a/src/rules/enum-value-snake-case.ts
+++ b/src/rules/enum-value-snake-case.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+import {
+  matchesAllowList,
+  trimPrefix,
+} from '#src/common/rule-config-helpers.js';
+import type { EnumRuleDefinition } from '#src/common/rule.js';
+import { toSnakeCase } from '#src/common/snake-case.js';
+
+const RULE_NAME = 'enum-value-snake-case';
+
+const Config = z
+  .object({
+    allowList: z.array(z.union([z.string(), z.instanceof(RegExp)])).optional(),
+    trimPrefix: z
+      .union([
+        z.string(),
+        z.instanceof(RegExp),
+        z.array(z.union([z.string(), z.instanceof(RegExp)])),
+      ])
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Checks that enum values are in snake_case.
+ *
+ * @example
+ *   // good
+ *   enum Example {
+ *     value
+ *   }
+ *
+ *   // good
+ *   enum Example {
+ *     value_1
+ *   }
+ *
+ *   // bad
+ *   enum Example {
+ *     Value
+ *   }
+ *
+ *   // bad
+ *   enum Example {
+ *     VALUE
+ *   }
+ *
+ *   // bad
+ *   enum Example {
+ *     camelCase
+ *   }
+ *
+ */
+export default {
+  ruleName: RULE_NAME,
+  configSchema: Config,
+  create: (config, context) => {
+    const { allowList, trimPrefix: trimPrefixConfig } = config;
+    return {
+      Enum: (enumObj) => {
+        enumObj.enumerators
+          .filter((enumerator) => enumerator.type === 'enumerator')
+          .forEach((enumValue) => {
+            if (matchesAllowList(enumValue.name, allowList)) {
+              return;
+            }
+            const nameWithoutPrefix = trimPrefix(
+              enumValue.name,
+              trimPrefixConfig,
+            );
+            if (nameWithoutPrefix !== toSnakeCase(nameWithoutPrefix)) {
+              const message = 'Enum value should be in snake_case.';
+              context.report({ enum: enumObj, message });
+            }
+          });
+      },
+    };
+  },
+} satisfies EnumRuleDefinition<z.infer<typeof Config>>;


### PR DESCRIPTION
Rules and implementations similar to those for Models.

(Requires https://github.com/loop-payments/prisma-lint/pull/458 to be merged first to make use of shared code introduced in `src/common/rule-config-helpers.ts`).