### PR TITLE
Add support for screaming snake case enum names.

### DIFF
--- a/src/common/snake-case.test.ts
+++ b/src/common/snake-case.test.ts
@@ -1,95 +1,129 @@
-import { toSnakeCase } from '#src/common/snake-case.js';
+import { toSnakeCase, type toSnakeCaseOptions } from '#src/common/snake-case.js';
+
+type TestVariant = [name: string, expected: string, options: toSnakeCaseOptions]
+
+function testOptionVariations(input: string, cases: TestVariant[]) {
+  cases.forEach((testCase) => {
+    it(testCase[0], () => {
+      const out = toSnakeCase(input, testCase[2]);
+      expect(out).toEqual(testCase[1]);
+    })
+  })
+}
 
 describe('toSnakeCase', () => {
   describe('cases', () => {
-    it('converts single-word string to snake case', () => {
-      const input = 'hello';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('hello');
+    describe('converts single-word string to snake case', () => {
+      testOptionVariations('hello', [
+        [""         , 'hello'             , {               }],
+        ["screaming", "HELLO"             , {screaming: true}]
+      ]);
     });
 
-    it('converts camel case string to snake case', () => {
-      const input = 'camelCaseString';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('camel_case_string');
+    describe('converts camel case string to snake case', () => {
+      testOptionVariations('camelCaseString', [
+        [""         , 'camel_case_string' , {               }],
+        ["screaming", "CAMEL_CASE_STRING" , {screaming: true}]
+      ]);
     });
 
-    it('converts Pascal case string to snake case', () => {
-      const input = 'PascalCaseString';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('pascal_case_string');
+    describe('converts Pascal case string to snake case', () => {
+      testOptionVariations('PascalCaseString', [
+        [""         , 'pascal_case_string', {               }],
+        ["screaming", "PASCAL_CASE_STRING", {screaming: true}]
+      ]);
     });
 
-    it('converts kebab case string to snake case', () => {
-      const input = 'kebab-case-string';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('kebab_case_string');
+    describe('converts kebab case string to snake case', () => {
+      testOptionVariations('kebab-case-string', [
+        [""         , 'kebab_case_string' , {               }],
+        ["screaming", 'KEBAB_CASE_STRING' , {screaming: true}]
+      ]);
     });
-
-    it('converts snake case string to snake case', () => {
-      const input = 'snake_case_string';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('snake_case_string');
+    describe('converts snake case string to snake case', () => {
+      testOptionVariations('snake_case_string', [
+        [""         , 'snake_case_string' , {               }],
+        ["screaming", 'SNAKE_CASE_STRING' , {screaming: true}]
+      ]);
+    });
+    describe('Preserves abbreviations when converting to snake case', () => {
+      testOptionVariations('TestAPISchema', [
+        [""         , 'test_api_schema' , {               }],
+        ["screaming", 'TEST_API_SCHEMA' , {screaming: true}]
+      ]);
     });
   });
 
   describe('compound words', () => {
-    it('respects compound words', () => {
-      const input = 'HelloWorldGraphQL';
-      const result = toSnakeCase(input, {
-        compoundWords: ['GraphQL'],
-      });
-      expect(result).toEqual('hello_world_graphql');
+    describe('respects compound words', () => {
+      testOptionVariations('HelloWorldGraphQL',[
+       [""              , "hello_world_graphql", { compoundWords: ['GraphQL']                 }],
+       ["with screaming", "HELLO_WORLD_GRAPHQL", { compoundWords: ['GraphQL'], screaming: true}]
+      ]);
     });
   });
 
   describe('require prefix', () => {
-    it('respects required prefix', () => {
-      const input = 'FooBar';
-      const result = toSnakeCase(input, {
-        requirePrefix: '_',
-      });
-      expect(result).toEqual('_foo_bar');
+    describe('respects required prefix', () => {
+      testOptionVariations('FooBar',[
+       [""              , "_foo_bar", { requirePrefix: '_'                  }],
+       ["with screaming", "_FOO_BAR", { requirePrefix: '_', screaming: true }]
+      ]);
     });
   });
+
+  describe('combine many options', () => {
+    describe('respects required prefix', () => {
+      const testOpts = { requirePrefix: '_', compoundWords: ['k8'], pluralize: true }
+      testOptionVariations('k8pod',[
+       [""              , "_k8_pods", testOpts                      ],
+       ["with screaming", "_K8_PODS", {...testOpts, screaming: true}]
+      ]);
+    });
+  })
 
   describe('numbers', () => {
-    it('makes numbers their own words', () => {
-      const input = 'AmazonS3';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('amazon_s_3');
+    describe('makes numbers their own words', () => {
+      testOptionVariations('AmazonS3',[
+       [""              , "amazon_s_3", {               }],
+       ["with screaming", "AMAZON_S_3", {screaming: true}]
+      ]);
     });
 
-    it('respects compound words with numbers', () => {
-      const input = 'AmazonS3';
-      const result = toSnakeCase(input, { compoundWords: ['S3'] });
-      expect(result).toEqual('amazon_s3');
+    describe('respects compound words with numbers', () => {
+      testOptionVariations('AmazonS3',[
+       [""             , "amazon_s3", { compoundWords: ['S3']                  }],
+       ["wth screaming", "AMAZON_S3", { compoundWords: ['S3'], screaming: true }]
+      ]);
     });
 
-    it('handles consecutive numbers', () => {
-      const input = 'Word1234Word';
-      const result = toSnakeCase(input);
-      expect(result).toEqual('word_1234_word');
+    describe('handles consecutive numbers', () => {
+      testOptionVariations('Word1234Word',[
+       [""              , "word_1234_word", {               }],
+       ["with screaming", "WORD_1234_WORD", {screaming: true}]
+      ]);
     });
   });
 
-  it('handles non-alphanumeric characters', () => {
-    const input = 'This@Is_A^Test';
-    const result = toSnakeCase(input);
-    expect(result).toEqual('this_is_a_test');
+  describe('handles non-alphanumeric characters', () => {
+      testOptionVariations('This@Is_A^Test',[
+       [""              , "this_is_a_test", {               }],
+       ["with screaming", "THIS_IS_A_TEST", {screaming: true}]
+      ]);
   });
 
   describe('without prefix', () => {
-    it('removes prefix', () => {
-      const input = 'PrefixWord';
-      const result = toSnakeCase(input, { trimPrefix: 'Prefix' });
-      expect(result).toEqual('word');
+    describe('removes prefix', () => {
+      testOptionVariations('PrefixWord',[
+       [""              , "word", { trimPrefix: 'Prefix'                  }],
+       ["with screaming", "WORD", { trimPrefix: 'Prefix', screaming: true }]
+      ]);
     });
 
-    it('does not remove prefix if it does not match', () => {
-      const input = 'SomethingElsePrefixWord';
-      const result = toSnakeCase(input, { trimPrefix: 'Pre' });
-      expect(result).toEqual('something_else_prefix_word');
+    describe('does not remove prefix if it does not match', () => {
+      testOptionVariations('SomethingElsePrefixWord',[
+       ["-", "something_else_prefix_word", { trimPrefix: 'Pre' }]
+      ]);
     });
   });
 });

--- a/src/common/snake-case.ts
+++ b/src/common/snake-case.ts
@@ -1,4 +1,46 @@
+import { Option } from 'commander';
 import pluralize from 'pluralize';
+
+export interface toSnakeCaseOptions {
+  /**
+   * A prefix to require in the input string
+   */
+  requirePrefix?: string;
+
+  /**
+   * A prefix to remove from the input string
+   * before converting to snake case.
+   */
+  trimPrefix?: string;
+
+  /**
+   * A list of words to keep as a single word
+   * when converting to snake case. For example,
+   * "GraphQL" will be converted to "graph_ql" by default,
+   * but if "GraphQL" is in this list, it will be converted
+   * to "graphql".
+   */
+  compoundWords?: string[];
+
+  /**
+   * Whether to convert to singular or plural snake case.
+   */
+  pluralize?: boolean;
+
+  /**
+   * A mapping from singular form to irregular plural form,
+   * for use when `pluralize` is true. Both forms should be
+   * in snake case.
+   * Example: `{ bill_of_lading: "bills_of_lading" }`
+   */
+  irregularPlurals?: Record<string, string>;
+
+  /** 
+  * Whether or not each segment of the snake_case term should be upper case.
+  * Example: SCREAMING_SNAKE_CASE (as opposed to screaming_snake_case)
+  */
+  screaming?: boolean;
+}
 
 /**
  * Returns a snake case string expected based on input string,
@@ -6,61 +48,30 @@ import pluralize from 'pluralize';
  */
 export function toSnakeCase(
   input: string,
-  options: {
-    /**
-     * A prefix to require in the input string
-     */
-    requirePrefix?: string;
-
-    /**
-     * A prefix to remove from the input string
-     * before converting to snake case.
-     */
-    trimPrefix?: string;
-
-    /**
-     * A list of words to keep as a single word
-     * when converting to snake case. For example,
-     * "GraphQL" will be converted to "graph_ql" by default,
-     * but if "GraphQL" is in this list, it will be converted
-     * to "graphql".
-     */
-    compoundWords?: string[];
-
-    /**
-     * Whether to convert to singular or plural snake case.
-     */
-    pluralize?: boolean;
-
-    /**
-     * A mapping from singular form to irregular plural form,
-     * for use when `pluralize` is true. Both forms should be
-     * in snake case.
-     * Example: `{ bill_of_lading: "bills_of_lading" }`
-     */
-    irregularPlurals?: Record<string, string>;
-  } = {},
+  options: toSnakeCaseOptions = {},
 ): string {
-  const { trimPrefix = '', compoundWords = [] } = options;
+  const { trimPrefix = '', compoundWords = [], screaming } = options;
   const inputWithoutPrefix = input.startsWith(trimPrefix)
     ? input.slice(trimPrefix.length)
     : input;
-  const compountWordsAsSnakeCase = compoundWords.map((compoundWord) =>
+  const compoundWordsAsSnakeCase = [...new Set(compoundWords.map((compoundWord) =>
     toSnakeCase(compoundWord),
-  );
+  ))];
   const snakeCase = inputWithoutPrefix
     .replace(/[\W]+/g, '_')
-    .replace(/([A-Z])/g, (_, group) => `_${group.toLowerCase()}`)
-    .replace(/\d+/g, '_$&')
+    // split on percieved word boundaries: aWord
+    .replace(/([^A-Z][A-Z])/g, (_, lowerUpper: string) => `${lowerUpper[0]}_${lowerUpper[1]}`)
+    // split after detecting the start of a new word AAAAWord
+    .replace(/([A-Z][a-z])/g, (_, wordStart: string) => `_${wordStart.toLowerCase()}`)
+    .replace(/\d+/g, '_$&_')
     .replace(/^_/, '')
-    .replace(/_+/g, '_');
-  const snakeCaseWithCompoundWords = compountWordsAsSnakeCase.reduce(
-    (acc, compoundWord) =>
-      acc.replace(compoundWord, compoundWord.replace(/_/g, '')),
+    .replace(/_$/, '')
+    .replace(/_+/g, '_').toLowerCase();
+  const snakeCaseWithCompoundWords = compoundWordsAsSnakeCase.reduce(
+    (acc, compoundWord) => acc.replace(compoundWord, compoundWord.replaceAll('_', '')),
     snakeCase,
   );
   let result = snakeCaseWithCompoundWords;
-
   if (options.pluralize) {
     if (options.irregularPlurals) {
       for (const [singular, plural] of Object.entries(
@@ -71,10 +82,11 @@ export function toSnakeCase(
     }
     result = pluralize(snakeCaseWithCompoundWords);
   }
-
-  if (options.requirePrefix) {
-    result = `${options.requirePrefix}${snakeCaseWithCompoundWords}`;
+  if (screaming) {
+    result = result.toUpperCase();
   }
-
+  if (options.requirePrefix) {
+    result = `${options.requirePrefix}${result}`;
+  }
   return result;
 }

--- a/src/rules/enum-value-snake-case.test.ts
+++ b/src/rules/enum-value-snake-case.test.ts
@@ -241,4 +241,32 @@ describe('enum-value-snake-case', () => {
       expect(violations.length).toEqual(1);
     });
   });
+
+  describe('with screaming set to true', () => {
+    const run = getRunner({ screaming: true  });
+    it('single upper-case term returns no violations', async () => {
+      const violations = await run(`
+        enum Example {
+          UPPER
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+    it('proper SCREAMING_SNAKE_CASE term returns no violations', async () => {
+      const violations = await run(`
+        enum Example {
+          UPPER_CASE
+        }
+        `);
+      expect(violations.length).toEqual(0);
+    });
+    it('usual snake_case results in a violation', async () => {
+      const violations = await run(`
+        enum Example {
+          snake_case
+        }
+        `);
+      expect(violations.length).toEqual(1);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6363,7 +6363,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>":
   version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
This PR adds support for enforcing that enum names are in `SCREAMING_SNAKE_CASE`.

There also a fixes bug that occurs if you combine ``requirePrefix`` and ``pluralize`` settings on ``toSnakeCase`` (fails to use ``result`` variable).

I've also adjusted the ``toSnakeCase`` function to try and preserve abbreviations (identified by runs of capital letters). Thus, while all the other test-cases are preserved as-is, a new one I've added ("Preserves abbreviations when converting to snake case") would have different results with the previous behavior: ``test_a_p_i_schema`` (old) vs ``test_api_schema`` (new).